### PR TITLE
因應強迫功能調整 OmsRequestPolicy 及 OmsRequestTrade

### DIFF
--- a/OmsErrCode/OmsErrCode.00xxx.cfg
+++ b/OmsErrCode/OmsErrCode.00xxx.cfg
@@ -56,6 +56,8 @@
 00504 = OrdTeam used up                           | 委託櫃號已用完(或沒設定)
 00505 = OrdNoMap not found                        | 委託書號對照表沒找到,可能是 MarketId 或 SessionId 不正確,或系統沒設定
 00506 = No OrdTeam permission                     | 無此委託櫃號權限
+00507 = No ScForce permission                     | 無此強迫權限
+00508 = OrdSt must be ec                          | 強迫操作,其委託狀態需要處於 因「風控檢查」拒絕 的狀態
 
 00600 = Order Routing request                                 | 請求 [主機{:AskToRemote:}] 協助繞送
 # 由繞送的接收端負責處理此錯誤.

--- a/f9omstw/OmsErrCode.h
+++ b/f9omstw/OmsErrCode.h
@@ -114,6 +114,12 @@ fon9_ENUM(OmsErrCode, uint16_t) {
    OmsErrCode_OrdNoMapNotFound = 505,
    /// OmsOrdNoMap::AllocOrdNo(); 自編委託書號(或自選櫃號), 但使用者無此櫃號權限.
    OmsErrCode_OrdTeamDeny = 506,
+   /// OmsTwsRequestForce::BeforeReqInCore();
+   /// 強迫操作, 使用者必須有對應的 ScForceFlag_ 權限.
+   OmsErrCode_DenyScForce_NoPermission = 507,
+   /// OmsTwsRequestForce::BeforeReqInCore();
+   /// 強迫操作, 其委託狀態需要處於 因「風控檢查」拒絕 的狀態.
+   OmsErrCode_DenyScForce_Bad_OrdSt = 508,
 
    // -----------------------------------------------------------------------
    /// 透過遠端主機協助繞送.

--- a/f9omstw/OmsRequestPolicy.cpp
+++ b/f9omstw/OmsRequestPolicy.cpp
@@ -131,6 +131,7 @@ OmsRequestPolicySP OmsRequestPolicyCfg::MakePolicy(OmsResource& res, fon9::intru
    pol->SetUserRightFlags(this->UserRights_.Flags_);
    pol->SetOrdTeamGroupCfg(res.OrdTeamGroupMgr_.SetTeamGroup(
       ToStrView(this->TeamGroupName_), ToStrView(this->UserRights_.AllowOrdTeams_)));
+   pol->SetScForceFlags(this->UserRights_.ScForceFlags_);
    for (const auto& item : this->IvList_) {
       auto ec = OmsAddIvConfig(*pol, ToStrView(item.first), item.second, *res.Brks_);
       if (ec != OmsIvKind::Unknown)

--- a/f9omstw/OmsRequestPolicy.hpp
+++ b/f9omstw/OmsRequestPolicy.hpp
@@ -19,6 +19,7 @@ class OmsRequestPolicy : public fon9::intrusive_ref_counter<OmsRequestPolicy> {
    mutable OmsIvRight         IvDenys_{};
    mutable OmsUserRightFlag   UserRightFlags_{};
    char                       padding___[3];
+   mutable f9oms_ScForceFlag  ScForceFlags_{};
 
    struct IvRec {
       OmsIvBase*        Iv_;
@@ -66,6 +67,12 @@ public:
    }
    void SetUserRightFlags(OmsUserRightFlag uRightFlags) const {
       this->UserRightFlags_ = uRightFlags;
+   }
+   f9oms_ScForceFlag ScForceFlags() const {
+      return this->ScForceFlags_;
+   }
+   void SetScForceFlags(f9oms_ScForceFlag scForceFlags) const {
+      this->ScForceFlags_ = scForceFlags;
    }
 
    /// - 如果 ivr 是 Subac:

--- a/f9omstw/OmsRequestTrade.hpp
+++ b/f9omstw/OmsRequestTrade.hpp
@@ -95,6 +95,9 @@ public:
       assert(this->Policy_.get() == nullptr);
       this->Policy_ = std::move(policy);
    }
+   void ForceResetPolicy(OmsRequestPolicySP policy) {
+      this->Policy_ = std::move(policy);
+   }
    const OmsRequestPolicy* Policy() const {
       return this->Policy_.get();
    }

--- a/f9omstws/OmsTwsRequest.hpp
+++ b/f9omstws/OmsTwsRequest.hpp
@@ -73,5 +73,24 @@ public:
                                            TradingRequest& queuingRequest) override;
 };
 
+/// 二段強迫下單要求
+class OmsTwsRequestForce : public f9omstw::OmsRequestUpd {
+   fon9_NON_COPY_NON_MOVE(OmsTwsRequestForce);
+   using base = f9omstw::OmsRequestUpd;
+   f9omstw::OmsOrderRaw* BeforeReqInCore(f9omstw::OmsRequestRunner& runner, f9omstw::OmsResource& res) override;
+public:
+   f9oms_ScForceFlag ScForceFlag_{};
+
+   using base::base;
+   OmsTwsRequestForce() = default;
+
+   static void MakeFields(fon9::seed::Fields& flds);
+
+   /// 將 iniReq 的 Policy 強制取代為強迫要求建立者的 Policy.
+   /// 衍生者可透過此決定該委託的權限.
+   /// 須注意重啟後的 iniReq 為 nullptr.
+   virtual void BeforeReq_ResetIniPolicy(const OmsRequestTrade* iniReq, const OmsRequestPolicy* reqPol);
+};
+
 } // namespaces
 #endif//__f9omstws_OmsTwsRequest_hpp__


### PR DESCRIPTION
1. OmsRequestPolicy 新增 ScForceFlags_ 後續風控得以取得其強迫權限. 
2. OmsRequestTrade 的 SetPolicy() 移除 assert, 因強迫者若是不同登入帳號, 需將強迫者權限設定至 iniRequest, 在初始化委託書號時才能以強迫者權限初始化.