### PR TITLE
新增二次強迫下單要求 OmsTwsRequestForce.

### DIFF
--- a/f9omstw/OmsRequestPolicy.cpp
+++ b/f9omstw/OmsRequestPolicy.cpp
@@ -131,6 +131,7 @@ OmsRequestPolicySP OmsRequestPolicyCfg::MakePolicy(OmsResource& res, fon9::intru
    pol->SetUserRightFlags(this->UserRights_.Flags_);
    pol->SetOrdTeamGroupCfg(res.OrdTeamGroupMgr_.SetTeamGroup(
       ToStrView(this->TeamGroupName_), ToStrView(this->UserRights_.AllowOrdTeams_)));
+   pol->SetScForceFlags(this->UserRights_.ScForceFlags_);
    for (const auto& item : this->IvList_) {
       auto ec = OmsAddIvConfig(*pol, ToStrView(item.first), item.second, *res.Brks_);
       if (ec != OmsIvKind::Unknown)

--- a/f9omstw/OmsRequestPolicy.hpp
+++ b/f9omstw/OmsRequestPolicy.hpp
@@ -19,6 +19,7 @@ class OmsRequestPolicy : public fon9::intrusive_ref_counter<OmsRequestPolicy> {
    mutable OmsIvRight         IvDenys_{};
    mutable OmsUserRightFlag   UserRightFlags_{};
    char                       padding___[3];
+   mutable f9oms_ScForceFlag  ScForceFlags_{};
 
    struct IvRec {
       OmsIvBase*        Iv_;
@@ -66,6 +67,12 @@ public:
    }
    void SetUserRightFlags(OmsUserRightFlag uRightFlags) const {
       this->UserRightFlags_ = uRightFlags;
+   }
+   f9oms_ScForceFlag ScForceFlags() const {
+      return this->ScForceFlags_;
+   }
+   void SetScForceFlags(f9oms_ScForceFlag scForceFlags) const {
+      this->ScForceFlags_ = scForceFlags;
    }
 
    /// - 如果 ivr 是 Subac:


### PR DESCRIPTION
1. OmsRequestPolicy 新增 ScForceFlags_ 後續風控得以取得其強迫權限;
2. OmsRequestTrade 新增ForceResetPolicy(), 因強迫者若是不同登入帳號, 需將強迫者權限設定至 iniRequest, 在初始化委託書號時才能以強迫者權限初始化;
3. 新增二段強迫下單要求 OmsTwsRequestForce;